### PR TITLE
fix "constants"

### DIFF
--- a/Resources/contao/dca/tl_c4g_map_profiles.php
+++ b/Resources/contao/dca/tl_c4g_map_profiles.php
@@ -164,7 +164,7 @@ $GLOBALS['TL_DCA']['tl_c4g_map_profiles'] = array
             'exclude'                 => true,
             'inputType'               => 'select',
             'options_callback'        => array('tl_c4g_map_profiles', 'getAllThemes'),
-            'eval'                    => array('tl_class'=>'clr', 'includeBlankOption' => true, blankOptionLabel => $GLOBALS['TL_LANG']['tl_c4g_map_profiles']['references']['default_theme']),
+            'eval'                    => array('tl_class'=>'clr', 'includeBlankOption' => true, 'blankOptionLabel' => $GLOBALS['TL_LANG']['tl_c4g_map_profiles']['references']['default_theme']),
             'reference'               => &$GLOBALS['TL_LANG']['tl_c4g_map_profiles']['references'],
             'sql'                     => "char(10) NOT NULL default ''"
         ),

--- a/Resources/contao/dca/tl_c4g_maps.php
+++ b/Resources/contao/dca/tl_c4g_maps.php
@@ -929,7 +929,7 @@ $GLOBALS['TL_DCA']['tl_c4g_maps'] = array
             'label'                   => &$GLOBALS['TL_LANG']['tl_c4g_maps']['ovp_request'],
             'exclude'                 => true,
             'inputType'               => 'textarea',
-            'eval'                    => array(allowHtml=>true, preserveTags=>true),
+            'eval'                    => array('allowHtml'=>true, 'preserveTags'=>true),
             'sql'                     => "text NULL"
         ),
         'ovp_bbox_limited' => array


### PR DESCRIPTION
Currently you get the following warnings under PHP 7.2:
```
PHP Warning: Use of undefined constant blankOptionLabel - assumed 'blankOptionLabel' (this will throw an Error in a future version of PHP) in /var/cache/prod/contao/dca/tl_c4g_map_profiles.php on line 168
PHP Warning: Use of undefined constant allowHtml - assumed 'allowHtml' (this will throw an Error in a future version of PHP) in /var/cache/prod/contao/dca/tl_c4g_maps.php on line 933
PHP Warning: Use of undefined constant preserveTags - assumed 'preserveTags' (this will throw an Error in a future version of PHP) in /var/cache/prod/contao/dca/tl_c4g_maps.php on line 933 
```
See also:

* https://github.com/Kuestenschmiede/con4gis_maps3/commit/4b6b97b0a268b8ed2a6e644a855d1ed01b4f6d4c#diff-1ca17f31029dfbe18678dee160348acb
* https://community.contao.org/de/showthread.php?70058-con4gis-und-quot-Error-in-a-future-version-of-PHP-quot