### PR TITLE
Symfony-5-fixes

### DIFF
--- a/Classes/Events/EditorConfigurationEvent.php
+++ b/Classes/Events/EditorConfigurationEvent.php
@@ -12,7 +12,7 @@
 namespace con4gis\MapsBundle\Classes\Events;
 
 use con4gis\MapsBundle\Entity\EditorConfiguration;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class EditorConfigurationEvent extends Event
 {

--- a/Classes/Events/LoadAreaFeaturesEvent.php
+++ b/Classes/Events/LoadAreaFeaturesEvent.php
@@ -11,7 +11,7 @@
 
 namespace con4gis\MapsBundle\Classes\Events;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class LoadAreaFeaturesEvent extends Event
 {

--- a/Classes/Events/LoadBaseLayersEvent.php
+++ b/Classes/Events/LoadBaseLayersEvent.php
@@ -10,7 +10,7 @@
  */
 namespace con4gis\MapsBundle\Classes\Events;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class LoadBaseLayersEvent extends Event
 {

--- a/Classes/Events/LoadFeatureFiltersEvent.php
+++ b/Classes/Events/LoadFeatureFiltersEvent.php
@@ -11,7 +11,7 @@
 namespace con4gis\MapsBundle\Classes\Events;
 
 use con4gis\MapsBundle\Classes\Filter\FeatureFilter;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class LoadFeatureFiltersEvent extends Event
 {

--- a/Classes/Events/LoadLayersEvent.php
+++ b/Classes/Events/LoadLayersEvent.php
@@ -10,7 +10,7 @@
  */
 namespace con4gis\MapsBundle\Classes\Events;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class LoadLayersEvent extends Event
 {

--- a/Classes/Events/LoadMapResourcesEvent.php
+++ b/Classes/Events/LoadMapResourcesEvent.php
@@ -10,7 +10,7 @@
  */
 namespace con4gis\MapsBundle\Classes\Events;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class LoadMapResourcesEvent extends Event
 {

--- a/Classes/Events/LoadMapdataEvent.php
+++ b/Classes/Events/LoadMapdataEvent.php
@@ -10,7 +10,7 @@
  */
 namespace con4gis\MapsBundle\Classes\Events;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class LoadMapdataEvent extends Event
 {

--- a/Classes/Events/LoadProfileEvent.php
+++ b/Classes/Events/LoadProfileEvent.php
@@ -10,7 +10,7 @@
  */
 namespace con4gis\MapsBundle\Classes\Events;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class LoadProfileEvent extends Event
 {

--- a/Classes/Events/LoadRouteFeaturesEvent.php
+++ b/Classes/Events/LoadRouteFeaturesEvent.php
@@ -11,7 +11,7 @@
 
 namespace con4gis\MapsBundle\Classes\Events;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class LoadRouteFeaturesEvent extends Event
 {

--- a/Classes/Listener/LoadAreaFeaturesListener.php
+++ b/Classes/Listener/LoadAreaFeaturesListener.php
@@ -18,7 +18,7 @@ use con4gis\MapsBundle\Classes\Events\LoadAreaFeaturesEvent;
 use con4gis\MapsBundle\Classes\LatLng;
 use con4gis\MapsBundle\Classes\Services\AreaService;
 use con4gis\MapsBundle\Entity\RoutingConfiguration;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class LoadAreaFeaturesListener
 {

--- a/Classes/Listener/LoadMapDataListener.php
+++ b/Classes/Listener/LoadMapDataListener.php
@@ -21,7 +21,7 @@ use con4gis\MapsBundle\Resources\contao\modules\ExternalMapElement;
 use con4gis\MapsBundle\Entity\RoutingConfiguration;
 use Contao\System;
 use Doctrine\ORM\EntityManager;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class LoadMapDataListener
 {

--- a/Classes/Listener/LoadRouteFeaturesListener.php
+++ b/Classes/Listener/LoadRouteFeaturesListener.php
@@ -15,7 +15,7 @@ use con4gis\MapsBundle\Classes\Events\LoadRouteFeaturesEvent;
 use con4gis\MapsBundle\Resources\contao\models\C4gMapProfilesModel;
 use con4gis\MapsBundle\Resources\contao\models\C4gMapsModel;
 use con4gis\MapsBundle\Resources\contao\models\C4gMapTablesModel;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class LoadRouteFeaturesListener
 {

--- a/Classes/MapDataConfigurator.php
+++ b/Classes/MapDataConfigurator.php
@@ -689,7 +689,7 @@ class MapDataConfigurator
         $eventDispatcher = System::getContainer()->get('event_dispatcher');
         $event = new LoadMapdataEvent();
         $event->setMapData($mapData);
-        $eventDispatcher->dispatch($event::NAME, $event);
+        $eventDispatcher->dispatch($event, $event::NAME);
         $mapData = $event->getMapData();
 
         // load resources

--- a/Classes/ResourceLoader.php
+++ b/Classes/ResourceLoader.php
@@ -120,7 +120,7 @@ class ResourceLoader extends coreResourceLoader
         $eventDispatcher = System::getContainer()->get('event_dispatcher');
         $event = new LoadMapResourcesEvent();
         $event->setMapData($mapData);
-        $eventDispatcher->dispatch($event::NAME, $event);
+        $eventDispatcher->dispatch($event, $event::NAME);
 
         // core scripts (2|2)
         if ($resources['core']) {

--- a/Classes/Services/AreaService.php
+++ b/Classes/Services/AreaService.php
@@ -39,7 +39,7 @@ class AreaService
         $event->setDistance($distance);
         $event->setLocation($location);
         $event->setProfile($profile);
-        $this->eventDispatcher->dispatch($event::NAME, $event);
+        $this->eventDispatcher->dispatch($event, $event::NAME);
         $eventResponse = $event->getReturnData();
         $matrixResponse = $eventResponse[0];
         if ($matrixResponse !== '[') {

--- a/Classes/Services/BaseLayerService.php
+++ b/Classes/Services/BaseLayerService.php
@@ -18,7 +18,7 @@ use con4gis\MapsBundle\Resources\contao\models\C4gMapProfilesModel;
 use con4gis\MapsBundle\Resources\contao\models\C4gMapSettingsModel;
 use Contao\Database;
 use Contao\FilesModel;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class BaseLayerService
 {

--- a/Classes/Services/FilterService.php
+++ b/Classes/Services/FilterService.php
@@ -14,7 +14,7 @@ use con4gis\MapsBundle\Classes\Filter\FeatureFilter;
 use con4gis\MapsBundle\Resources\contao\models\C4gMapProfilesModel;
 use con4gis\MapsBundle\Resources\contao\models\C4gMapsModel;
 use Contao\Database;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class FilterService
 {

--- a/Classes/Services/LayerService.php
+++ b/Classes/Services/LayerService.php
@@ -17,7 +17,7 @@ use con4gis\CoreBundle\Resources\contao\models\C4gLogModel;
 use con4gis\MapsBundle\Classes\Utils;
 use con4gis\MapsBundle\Resources\contao\models\C4gMapsModel;
 use Contao\FrontendUser;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class LayerService
 {

--- a/Classes/Services/ProfileService.php
+++ b/Classes/Services/ProfileService.php
@@ -12,7 +12,7 @@ namespace con4gis\MapsBundle\Classes\Services;
 
 use con4gis\CoreBundle\Resources\contao\models\C4gSettingsModel;
 use con4gis\MapsBundle\Classes\Events\LoadProfileEvent;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class ProfileService
 {
@@ -34,7 +34,7 @@ class ProfileService
     {
         $event = new LoadProfileEvent();
         $event->setProfileId(intval($profileId));
-        $this->eventDispatcher->dispatch($event::NAME, $event);
+        $this->eventDispatcher->dispatch($event, $event::NAME);
 
         $profileId = $event->getProfileId();
         if (!$profileId) {

--- a/Classes/Services/RouteService.php
+++ b/Classes/Services/RouteService.php
@@ -18,7 +18,7 @@ use con4gis\MapsBundle\Classes\Events\LoadRouteFeaturesEvent;
 use con4gis\MapsBundle\Classes\Polyline;
 use con4gis\MapsBundle\Entity\RoutingConfiguration;
 use Contao\System;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class RouteService extends \Frontend
 {
@@ -92,7 +92,7 @@ class RouteService extends \Frontend
                 $event->setProfileId($profileId);
                 $event->setPoints($points);
                 $event->setDetour($detour);
-                $this->eventDispatcher->dispatch($event::NAME, $event);
+                $this->eventDispatcher->dispatch($event, $event::NAME);
                 $routeData['features'] = $event->getFeatures();
                 $routeData['bbox'] = $event->getBbox();
                 $routeData['type'] = $objLayer->location_type === 'overpass' ? 'overpass' : 'notOverpass';

--- a/Controller/EditorController.php
+++ b/Controller/EditorController.php
@@ -43,7 +43,7 @@ class EditorController extends BaseController
 //        if (!self::$outputFromCache) {
 //            $configurationEvent = new EditorConfigurationEvent();
 //            $configurationEvent->setConfigId($configId);
-//            $this->eventDispatcher->dispatch($configurationEvent::NAME, $configurationEvent);
+//            $this->eventDispatcher->dispatch($configurationEvent, $configurationEvent::NAME);
 //            $formattedProjects = [];
 //            $editorConfig = $configurationEvent->getEditorConfig();
 //            $editorConfig['projects'] = $formattedProjects;

--- a/Controller/FilterController.php
+++ b/Controller/FilterController.php
@@ -53,7 +53,7 @@ class FilterController extends BaseController
         $event->setProfileId($profileId);
         $event->setFilters($filters);
         $event->setAddData(["language" => $lang]);
-        $this->eventDispatcher->dispatch($event::NAME, $event);
+        $this->eventDispatcher->dispatch($event, $event::NAME);
         $filters = $event->getFilters();
         return new JsonResponse($filters);
     }

--- a/Controller/LayerController.php
+++ b/Controller/LayerController.php
@@ -89,7 +89,7 @@ class LayerController extends BaseController
                 $event = new LoadLayersEvent();
                 $event->setLayerData($arrLayerData);
                 $event->setAdditionalData(["language" => $lang]);
-                $this->eventDispatcher->dispatch($event::NAME, $event);
+                $this->eventDispatcher->dispatch($event, $event::NAME);
                 $arrLayerData = $event->getLayerData();
             }
         }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -32,24 +32,28 @@ services:
 
     con4gis\MapsBundle\Controller\LayerController:
         class: con4gis\MapsBundle\Controller\LayerController
+        autowire: true
         public: true
         arguments:
             - "@service_container"
 
     con4gis\MapsBundle\Controller\BaselayerController:
         class: con4gis\MapsBundle\Controller\BaselayerController
+        autowire: true
         public: true
         arguments:
             - "@service_container"
 
     con4gis\MapsBundle\Controller\LocationstyleController:
         class: con4gis\MapsBundle\Controller\LocationstyleController
+        autowire: true
         public: true
         arguments:
             - "@service_container"
 
     con4gis\MapsBundle\Controller\MapsController:
         class: con4gis\MapsBundle\Controller\MapsController
+        autowire: true
         public: true
         arguments:
             - "@service_container"
@@ -57,6 +61,7 @@ services:
 
     con4gis\MapsBundle\Controller\FilterController:
         class: con4gis\MapsBundle\Controller\FilterController
+        autowire: true
         public: true
         arguments:
             - "@con4gis.filter_service"
@@ -76,6 +81,7 @@ services:
 
     con4gis\MapsBundle\Controller\RoutingController:
         class: con4gis\MapsBundle\Controller\RoutingController
+        autowire: true
         public: true
         arguments:
             - "@service_container"
@@ -106,6 +112,7 @@ services:
 
     con4gis\MapsBundle\Controller\EditorController:
         class: con4gis\MapsBundle\Controller\EditorController
+        autowire: true
         public: true
         arguments:
             - "@service_container"


### PR DESCRIPTION
Contains some Symfony 4, 4.3 and 5 fixes
Since Symfony 4.4 every controller has to be autowired explicitly to its service
Symfony\Component\EventDispatcher is deprecated since Symfony 4.3 and incompatible with Symfony 5
Also ->dispatch(); changed parameters