### PR TITLE
Fix image sizes service usage

### DIFF
--- a/src/Resources/contao/dca/tl_c4g_map_locstyles.php
+++ b/src/Resources/contao/dca/tl_c4g_map_locstyles.php
@@ -16,7 +16,7 @@ use Contao\System;
 use Contao\Message;
 
 $filteredSizes = [];
-$imageSizes = System::getContainer() && System::getContainer()->get('contao.image.image_sizes') ? System::getContainer()->get('contao.image.image_sizes')->getAllOptions() : false;
+$imageSizes = System::getContainer() && System::getContainer()->has('contao.image.sizes') ? System::getContainer()->get('contao.image.sizes')->getAllOptions() : false;
 $just = 'proportional';
 
 if ($imageSizes !== false) {


### PR DESCRIPTION
Fixes the following error:

```
  [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]
  You have requested a non-existent service "contao.image.image_sizes". Did you mean one of these: "contao.image.imagine", "contao.image.imagine_svg", "contao.image.resizer", "contao.image.sizes"?  


Exception trace:
  at vendor\symfony\dependency-injection\Container.php:263
 Symfony\Component\DependencyInjection\Container::make() at vendor\symfony\dependency-injection\Container.php:211
 Symfony\Component\DependencyInjection\Container->get() at var\cache\dev\contao\dca\tl_c4g_map_locstyles.php:5 
```

**However** @coastforge-mei (etc.) I _strongly_ recommend that you do not use this this way. Instead you should implement a proper event listener that implements one `options_callback` that is then applied to the respective fields.